### PR TITLE
[VICO-4] Adding Custom Authenticator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/http-client": "6.3.*",
         "symfony/messenger": "6.3.*",
         "symfony/runtime": "6.3.*",
+        "symfony/security-bundle": "6.3.*",
         "symfony/twig-bundle": "6.3.*",
         "symfony/validator": "6.3.*",
         "symfony/yaml": "6.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "accba8a7bad9ca5351812183ac99321a",
+    "content-hash": "e454c06f21ba8c195979c804b5ae22b0",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -4490,6 +4490,78 @@
             "time": "2023-05-12T14:21:09+00:00"
         },
         {
+            "name": "symfony/password-hasher",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/password-hasher.git",
+                "reference": "d23ad221989e6b8278d050cabfd7b569eee84590"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/d23ad221989e6b8278d050cabfd7b569eee84590",
+                "reference": "d23ad221989e6b8278d050cabfd7b569eee84590",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "conflict": {
+                "symfony/security-core": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0",
+                "symfony/security-core": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PasswordHasher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin Chalas",
+                    "email": "robin.chalas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides password hashing utilities",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/password-hasher/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-02-14T09:04:20+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-grapheme",
             "version": "v1.27.0",
             "source": {
@@ -4815,6 +4887,83 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "db9358571ce63f09c439c2fee6c12e5b090b69ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/db9358571ce63f09c439c2fee6c12e5b090b69ac",
+                "reference": "db9358571ce63f09c439c2fee6c12e5b090b69ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/property-info": "^5.4|^6.0"
+            },
+            "require-dev": {
+                "symfony/cache": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-19T08:06:44+00:00"
+        },
+        {
             "name": "symfony/property-info",
             "version": "v6.3.0",
             "source": {
@@ -5057,6 +5206,354 @@
                 }
             ],
             "time": "2023-03-14T15:56:29+00:00"
+        },
+        {
+            "name": "symfony/security-bundle",
+            "version": "v6.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-bundle.git",
+                "reference": "f4fe79d7ebafd406e1a6f646839bfbbed641d8b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/f4fe79d7ebafd406e1a6f646839bfbbed641d8b2",
+                "reference": "f4fe79d7ebafd406e1a6f646839bfbbed641d8b2",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "ext-xml": "*",
+                "php": ">=8.1",
+                "symfony/clock": "^6.3",
+                "symfony/config": "^6.1",
+                "symfony/dependency-injection": "^6.2",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.2",
+                "symfony/http-kernel": "^6.2",
+                "symfony/password-hasher": "^5.4|^6.0",
+                "symfony/security-core": "^6.2",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/security-http": "^6.3"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/framework-bundle": "<6.3",
+                "symfony/http-client": "<5.4",
+                "symfony/ldap": "<5.4",
+                "symfony/twig-bundle": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4|^2",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dom-crawler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/framework-bundle": "^6.3",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/ldap": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/twig-bridge": "^5.4|^6.0",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4",
+                "web-token/jwt-checker": "^3.1",
+                "web-token/jwt-signature-algorithm-ecdsa": "^3.1",
+                "web-token/jwt-signature-algorithm-eddsa": "^3.1",
+                "web-token/jwt-signature-algorithm-hmac": "^3.1",
+                "web-token/jwt-signature-algorithm-none": "^3.1",
+                "web-token/jwt-signature-algorithm-rsa": "^3.1"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\SecurityBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-bundle/tree/v6.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-21T12:08:28+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "9cb74232e978be1440d2bb7daf91eb40a9363890"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/9cb74232e978be1440d2bb7daf91eb40a9363890",
+                "reference": "9cb74232e978be1440d2bb7daf91eb40a9363890",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2.5|^3",
+                "symfony/password-hasher": "^5.4|^6.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/http-foundation": "<5.4",
+                "symfony/ldap": "<5.4",
+                "symfony/security-guard": "<5.4",
+                "symfony/validator": "<5.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "psr/container": "^1.1|^2.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/ldap": "^5.4|^6.0",
+                "symfony/string": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Core\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - Core Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-core/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-28T15:57:00+00:00"
+        },
+        {
+            "name": "symfony/security-csrf",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-csrf.git",
+                "reference": "1f505c9060bde692eb37718c78a91d95d9abeeec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/1f505c9060bde692eb37718c78a91d95d9abeeec",
+                "reference": "1f505c9060bde692eb37718c78a91d95d9abeeec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/security-core": "^5.4|^6.0"
+            },
+            "conflict": {
+                "symfony/http-foundation": "<5.4"
+            },
+            "require-dev": {
+                "symfony/http-foundation": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Csrf\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - CSRF Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-csrf/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-21T14:41:17+00:00"
+        },
+        {
+            "name": "symfony/security-http",
+            "version": "v6.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-http.git",
+                "reference": "36d2bdd09c33f63014dc65f164a77ff099d256c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/36d2bdd09c33f63014dc65f164a77ff099d256c6",
+                "reference": "36d2bdd09c33f63014dc65f164a77ff099d256c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^6.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/security-core": "^6.3"
+            },
+            "conflict": {
+                "symfony/clock": "<6.3",
+                "symfony/event-dispatcher": "<5.4.9|>=6,<6.0.9",
+                "symfony/http-client-contracts": "<3.0",
+                "symfony/security-bundle": "<5.4",
+                "symfony/security-csrf": "<5.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/clock": "^6.3",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-client-contracts": "^3.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/security-csrf": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
+                "web-token/jwt-checker": "^3.1",
+                "web-token/jwt-signature-algorithm-ecdsa": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Http\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - HTTP Integration",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-http/tree/v6.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-18T15:50:12+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,4 +12,5 @@ return [
   JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
   Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
   Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+  Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
 ];

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -1,0 +1,2 @@
+parameters:
+  voting.system.authToken: '%env(AUTH_TOKEN_VOTING_SYSTEM)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,9 +1,13 @@
+imports:
+    - { resource: parameters.yaml }
+
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    app.env: '%env(APP_ENV)%'
 
 services:
     # default configuration for services in *this* file

--- a/src/Core/Security/ApiTokenAuthenticator.php
+++ b/src/Core/Security/ApiTokenAuthenticator.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Core\Security;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+/**
+ * Class ApiTokenAuthenticator
+ *
+ * Authenticator used to authenticate Vicoland endpoints.
+ * Not real authentication, comparing token with hardcoded token in ENV
+ */
+class ApiTokenAuthenticator extends AbstractAuthenticator
+{
+  /** @var string key used in HTTP header request to Authorize on server */
+  private const AUTHORIZATION_HEADER_KEY = 'Authorization';
+
+  /**
+   * ApiTokenAuthenticator constructor
+   *
+   * @param ParameterBagInterface $params used for getting parameters from configuration files
+   * @param UserProvider $userProvider used for getting user
+   */
+  public function __construct(private ParameterBagInterface $params, private UserProvider $userProvider)
+  {
+  }
+
+  /**
+   * Check if authenticator should be called
+   * If no API key is defined from backend side disable auth
+   *
+   * @param Request $request
+   * @return bool|null
+   */
+  public function supports(Request $request): ?bool
+  {
+    return $request->headers->has(self::AUTHORIZATION_HEADER_KEY);
+  }
+
+  /**
+   * Based on received api token determine if someone can access the endpoint
+   *
+   * @param Request $request
+   * @return Passport
+   */
+  public function authenticate(Request $request): Passport
+  {
+    if (empty($request->headers->all(self::AUTHORIZATION_HEADER_KEY))) {
+      throw new CustomUserMessageAuthenticationException('Authorization header is missing');
+    };
+
+    $getAuthToken = $this->params->get('voting.system.authToken');
+
+    $authorization = $request->headers->get(self::AUTHORIZATION_HEADER_KEY) ?? '';
+    
+    $apiToken = str_contains($authorization, 'Bearer') ? substr($authorization, strlen('Bearer ')) : $authorization;
+
+    if (null == $apiToken) {
+      // The token header was empty, authentication fails with HTTP Status
+      // Code 401 "Unauthorized"
+      throw new CustomUserMessageAuthenticationException('No API token provided');
+    }
+
+    if ($getAuthToken !== $apiToken) {
+      throw new CustomUserMessageAuthenticationException('Given API token is not valid');
+    }
+
+
+    return new SelfValidatingPassport(
+      new UserBadge($apiToken, function () use ($apiToken) {
+        return $this->userProvider->loadUserByIdentifier($apiToken);
+      })
+    );
+  }
+
+  /**
+   * Determine what we should do if authentication is passed.
+   *
+   * If you return null, the current request will continue, and the user
+   * will be authenticated. This makes sense, for an API.
+   *
+   * @param Request $request
+   * @param TokenInterface $token
+   * @param string $firewallName
+   * @return Response|null
+   */
+  public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+  {
+    // on success, let the request continue
+    return null;
+  }
+
+  /**
+   * Determine how we handle failed authentication
+   *
+   * @param Request $request
+   * @param AuthenticationException $exception
+   * @return Response|null
+   */
+  public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+  {
+    $data = [
+      'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
+    ];
+
+    if ($this->params->get('app.env') === 'prod') {
+      return new Response('', Response::HTTP_UNAUTHORIZED);
+    }
+
+    return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+  }
+}

--- a/src/Core/Security/ApiTokenAuthenticator.php
+++ b/src/Core/Security/ApiTokenAuthenticator.php
@@ -44,7 +44,11 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
    */
   public function supports(Request $request): ?bool
   {
-    return $request->headers->has(self::AUTHORIZATION_HEADER_KEY);
+    if (empty($request->headers->all(self::AUTHORIZATION_HEADER_KEY))) {
+      throw new CustomUserMessageAuthenticationException('Authorization header is missing', code: 401);
+    };
+
+    return true;
   }
 
   /**
@@ -55,14 +59,10 @@ class ApiTokenAuthenticator extends AbstractAuthenticator
    */
   public function authenticate(Request $request): Passport
   {
-    if (empty($request->headers->all(self::AUTHORIZATION_HEADER_KEY))) {
-      throw new CustomUserMessageAuthenticationException('Authorization header is missing');
-    };
-
     $getAuthToken = $this->params->get('voting.system.authToken');
 
     $authorization = $request->headers->get(self::AUTHORIZATION_HEADER_KEY) ?? '';
-    
+
     $apiToken = str_contains($authorization, 'Bearer') ? substr($authorization, strlen('Bearer ')) : $authorization;
 
     if (null == $apiToken) {

--- a/src/Core/Security/User.php
+++ b/src/Core/Security/User.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Core\Security;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Class User
+ */
+class User implements UserInterface
+{
+  /**
+   * Returns the roles granted to the user.
+   *
+   * @return array<string>
+   */
+  public function getRoles(): array
+  {
+    // TODO: Implement getRoles() method.
+    return [];
+  }
+
+  /**
+   * Removes sensitive data from the user.
+   *
+   * @return void
+   */
+  public function eraseCredentials()
+  {
+    // TODO: Implement eraseCredentials() method.
+  }
+
+  /**
+   * Returns the identifier for this user (e.g. its username or email address).
+   *
+   * @return string
+   */
+  public function getUserIdentifier(): string
+  {
+    // TODO: Implement getUserIdentifier() method.
+
+    return '';
+  }
+
+  /**
+   * Whether this provider supports the given user class.
+   *
+   * @param mixed $class
+   * @return bool
+   */
+  public function supportsClass(mixed $class): bool
+  {
+    return $class === self::class;
+  }
+}

--- a/src/Core/Security/UserProvider.php
+++ b/src/Core/Security/UserProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Core\Security;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+
+/**
+ * Class UserProvider
+ */
+class UserProvider implements UserProviderInterface
+{
+  /**
+   * Define new User for authentication's SelfValidatingPassport
+   *
+   * @param mixed $identifier
+   * @return UserInterface
+   */
+  public function loadUserByIdentifier(mixed $identifier): UserInterface
+  {
+    return new User();
+  }
+
+  /**
+   * Refreshes the user.
+   *
+   * It is up to the implementation to decide if the user data should be
+   * totally reloaded
+   *
+   * @param UserInterface $user
+   * @return User
+   */
+  public function refreshUser(UserInterface $user): User
+  {
+    if (!$user instanceof User) {
+      throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+    }
+
+    return new User();
+  }
+
+  /**
+   * Whether this provider supports the given user class.
+   *
+   * @param string $class
+   * @return bool
+   */
+  public function supportsClass(string $class): bool
+  {
+    return User::class === $class;
+  }
+}

--- a/src/VotingSystem/config/packages/security.yaml
+++ b/src/VotingSystem/config/packages/security.yaml
@@ -1,0 +1,25 @@
+security:
+  # Since symfony/security-bundle 6.2: The "enable_authenticator_manager" option at "security" is deprecated.
+  enable_authenticator_manager: true
+
+  # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+  providers:
+    custom_user_provider:
+      id: App\Core\Security\UserProvider
+
+  firewalls:
+    dev:
+      pattern: ^/(_(profiler|wdt)|css|images|js)/
+      security: false
+    voting_system:
+      lazy: true
+      pattern: ^/api/v1
+      provider: custom_user_provider
+      custom_authenticators:
+        - App\Core\Security\ApiTokenAuthenticator
+
+  # Easy way to control access for large sections of your site
+  # Note: Only the *first* access control that matches will be used
+  access_control:
+    - { path: ^/api/doc, roles: PUBLIC_ACCESS }
+    - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/symfony.lock
+++ b/symfony.lock
@@ -192,6 +192,18 @@
             "config/routes.yaml"
         ]
     },
+    "symfony/security-bundle": {
+        "version": "6.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.0",
+            "ref": "8a5b112826f7d3d5b07027f93786ae11a1c7de48"
+        },
+        "files": [
+            "config/packages/security.yaml"
+        ]
+    },
     "symfony/twig-bundle": {
         "version": "6.3",
         "recipe": {

--- a/tests/BaseApiWebTestCase.php
+++ b/tests/BaseApiWebTestCase.php
@@ -34,6 +34,11 @@ abstract class BaseApiWebTestCase extends WebTestCase
    */
   private ?ContainerAwareLoader $fixtureLoader;
 
+  /**
+   * @var string
+   */
+  protected string $authToken;
+
   public function setUp(): void
   {
     // This calls KernelTestCase::bootKernel(), and creates a
@@ -42,6 +47,9 @@ abstract class BaseApiWebTestCase extends WebTestCase
     $this->entityManager = self::getContainer()->get('doctrine')->getManager();
     $this->getFixtureLoader();
     $this->getFixtureExecutor();
+
+    // get auth token for tests
+    $this->authToken = strval($this->client->getContainer()->getParameter('voting.system.authToken'));
   }
 
   /**
@@ -112,7 +120,7 @@ abstract class BaseApiWebTestCase extends WebTestCase
       $path
     );
 
-    $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
   }
 
   /**
@@ -152,6 +160,6 @@ abstract class BaseApiWebTestCase extends WebTestCase
       ]
     );
 
-    $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
   }
 }

--- a/tests/VotingSystem/Action/RateProjectTest.php
+++ b/tests/VotingSystem/Action/RateProjectTest.php
@@ -53,7 +53,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $response = (array)json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -83,7 +85,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     /** @var array<string> $response */
@@ -111,7 +115,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     /** @var array<string> $response */
@@ -141,7 +147,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
 
@@ -179,7 +187,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $response = (array)json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -213,7 +223,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $response = (array)json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -247,7 +259,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $response = (array)json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -281,7 +295,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $response = (array)json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -314,6 +330,7 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
       [],
       [
         'CONTENT_TYPE' => 'application/json',
+        'HTTP_authorization' => $this->authToken
       ],
       json_encode([
         'rating' => self::TEST_PROJECT_RATING,
@@ -354,6 +371,7 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
       [],
       [
         'CONTENT_TYPE' => 'application/json',
+        'HTTP_authorization' => $this->authToken
       ],
       json_encode([
         'rating' => self::TEST_PROJECT_RATING,
@@ -394,7 +412,9 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'value_for_money_rating' => self::TEST_PROJECT_RETURN_VALUE_RATING
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $response = (array)json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -428,9 +448,70 @@ Society excited by cottage private an it esteems. Fully begin on by wound an. Gi
         'review' => self::TEST_PROJECT_REVIEW_LONG
       ],
       [],
-      []
+      [
+        'HTTP_authorization' => $this->authToken
+      ]
     );
 
     $this->assertResponseIsSuccessful();
+  }
+
+  /**
+   * Non-valid auth token is provided.
+   * Unauthorized exception is triggered
+   *
+   * @return void
+   */
+  public function testRateProjectWithoutAuthToken(): void
+  {
+    $this->addFixture(new ClientFixture());
+    $this->addFixture(new ProjectWithoutVicoFixture());
+    $this->executeFixtures();
+
+    /** @var Project $project */
+    $project = $this->getFixtureByReference(ProjectWithoutVicoFixture::TEST_PROJECT_WITHOUT_VICO_REFERENCE);
+
+    $this->testWithoutAuthTokenBase(Request::METHOD_PATCH, 'api/v1/project/' . $project->getId());
+  }
+
+  /**
+   * Non-valid auth token is provided.
+   * Unauthorized exception is triggered
+   *
+   * @return void
+   */
+  public function testRateProjectWithInvalidAuthToken(): void
+  {
+    $this->addFixture(new ClientFixture());
+    $this->addFixture(new ProjectWithoutVicoFixture());
+    $this->executeFixtures();
+
+    /** @var Project $project */
+    $project = $this->getFixtureByReference(ProjectWithoutVicoFixture::TEST_PROJECT_WITHOUT_VICO_REFERENCE);
+
+    $this->testWithInvalidAuthTokenBase(
+      Request::METHOD_PATCH,
+      'api/v1/project/' . $project->getId()
+    );
+  }
+
+  /**
+   * Testing case when there are no authorization
+   *
+   * @return void
+   */
+  public function testRateProjectWithoutAuthorization()
+  {
+    $this->addFixture(new ClientFixture());
+    $this->addFixture(new ProjectWithoutVicoFixture());
+    $this->executeFixtures();
+
+    /** @var Project $project */
+    $project = $this->getFixtureByReference(ProjectWithoutVicoFixture::TEST_PROJECT_WITHOUT_VICO_REFERENCE);
+
+    $this->testWithoutAuthorizationBase(
+      Request::METHOD_PATCH,
+      'api/v1/project/' . $project->getId()
+    );
   }
 }


### PR DESCRIPTION
## Describe your changes

## Checklist before requesting a review
- [x] in `src\Core` added `Security` directory with custom `ApiTokenAuthenticator.php` authenticator and coresponding `User.php` and `UserProvider.php` which are necessary for our authenticator to work
- [x] in `src/VotingSystem/config/packages/security.yaml` we configure our security to watch newly created custom `ApiTokenAuthenticator.php` and use newly created `UserProvider`, also we disable authorization for `api/doc` endpoint which should be public
- [x] install security dependency through composer
- [x] add `authToken` to `BaseApiWebTestCase.php` and update all tests
- [x] write additional test for athorization  
